### PR TITLE
Small fix for not-loading objects damaged after spawn

### DIFF
--- a/persistence/world/oFunctions.sqf
+++ b/persistence/world/oFunctions.sqf
@@ -47,7 +47,6 @@ o_isSaveable = {
 
   init(_class, typeOf _obj);
 
-  if (!(alive _obj)) exitWith {false};
   if ([_obj] call sh_isSaveableVehicle) exitWith {false}; //already being saved as a vehicle, don't save it
   if ([_obj] call o_isInSaveList) exitWith {true}; //not sure what this "saveList" thing is ...
 
@@ -347,6 +346,7 @@ o_addSaveObject = {
   
 
   if (not([_obj] call o_isSaveable)) exitWith {};
+  if (!(alive _obj)) exitWith {};
 
   //diag_log format["will save %1", _obj];
   def(_class);


### PR DESCRIPTION
Simple solution for loading damaged objects. Should we restore it HP after it's loaded?
